### PR TITLE
MULTISITE-13676 - Setting the value of the proposal script on install

### DIFF
--- a/nexteuropa_newsroom.install
+++ b/nexteuropa_newsroom.install
@@ -60,7 +60,7 @@ function nexteuropa_newsroom_install() {
   variable_set('newsroom_display_agenda', 1);
   variable_set('newsroom_agenda_after_highlights', 1);
   variable_set('newsroom_display_highlights_begin', 1);
-  variable_set('newsroom_proposal_script', NEXTEUROPA_NEWSROOM_PROPOSAL_ACCESS);
+  variable_set('newsroom_proposal_script', NEXTEUROPA_NEWSROOM_PROPOSAL_SCRIPT);
 
   $bundles = array('newsroom_item', 'newsroom_selection');
   $backup = variable_get('nexteuropa_newsroom_view_modes_backup', FALSE);


### PR DESCRIPTION
Small bugfix: Setting the value of the news proposal script to NEXTEUROPA_NEWSROOM_PROPOSAL_SCRIPT instead of NEXTEUROPA_NEWSROOM_PROPOSAL_ACCESS.
